### PR TITLE
Adjust config to prevent circular dependency

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,7 +1,6 @@
 ---
 Name: sunnysvgimages
-After:
-  - 'framework/*'
+After: '*'
 ---
 SilverStripe\Admin\LeftAndMain:
   extra_requirements_css:


### PR DESCRIPTION
The after section is not really needed as the config is not dependent on other configs to be loaded first, but going from specifically `framework/*` to a wider `*` prevents a yaml config circular dependency in some projects where other modules use `After: '*'` as well.